### PR TITLE
Add Feature to scrape Host Metadata

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,8 @@ icinga2:
   passwd: cf593406ffcfd2ef
   # All prometheus metrics will be prefixed with this string
   metric_prefix: icinga2
+  # Enables a separate request to fetch host metadata like state and state_type
+  enable_scrape_metadata: Yes
   # Example of host customer variables that should be added as labels and how to be translated
   host_custom_vars:
     # Specify which custom_vars to extract from hosts in icinga2

--- a/icinga2_exporter/monitorconnection.py
+++ b/icinga2_exporter/monitorconnection.py
@@ -156,7 +156,7 @@ class MonitorConfig(object, metaclass=Singleton):
     async def async_get_perfdata(self, hostname):
         # Get performance data from Monitor and return in json format
         body = {"joins": ["host.vars"],
-                "attrs": ["__name", "display_name", "check_command", "last_check_result", "vars", "host_name"],
+                "attrs": ["__name", "display_name", "check_command", "last_check_result", "vars", "host_name", "downtime_depth", "acknowledgement","max_check_attempts", "last_reachable", "state", "state_type"],
                 "filter": 'service.host_name==\"{}\"'.format(hostname)}
 
         data_json = await self.async_post(self.url_query_service_perfdata, body)

--- a/icinga2_exporter/perfdata.py
+++ b/icinga2_exporter/perfdata.py
@@ -66,7 +66,7 @@ class Perfdata:
                     labels.update(Perfdata.get_host_custom_vars(serivce_attrs))
 
 
-                    for perf_string in serivce_attrs['attrs']['last_check_result']['performance_data']:
+                    for perf_string in service_attrs['attrs']['last_check_result']['performance_data']:
                         perf = Perfdata.parse_perfdata(perf_string)
 
                         # For each perfdata metrics

--- a/icinga2_exporter/perfdata.py
+++ b/icinga2_exporter/perfdata.py
@@ -58,6 +58,7 @@ class Perfdata:
                         service_attrs['attrs']['last_check_result'] and \
                         service_attrs['attrs']['last_check_result']['performance_data'] is not None:
                     check_command = service_attrs['attrs']['check_command']
+                    service = service_attrs['attrs']['display_name']
                     # Get default labels
                     labels = {'hostname': service_attrs['attrs']['host_name'],
                               'service': service_attrs['attrs']['display_name']}
@@ -71,7 +72,7 @@ class Perfdata:
                         metadata_value = self.normalize_metadata_value(service_attrs['attrs'].get(entry))
 
 
-                        prometheus_key = self.format_prometheus_metrics_name(check_command + "_metadata", entry,
+                        prometheus_key = self.format_prometheus_metrics_name("{}_{}_{}".format(check_command, service, "metadata"), entry,
                                                                                      {})
                         
                         prometheus_key_with_labels = Perfdata.concat_metrics_name_and_labels(labels,

--- a/icinga2_exporter/perfdata.py
+++ b/icinga2_exporter/perfdata.py
@@ -72,7 +72,7 @@ class Perfdata:
                         metadata_value = self.normalize_metadata_value(service_attrs['attrs'].get(entry))
 
 
-                        prometheus_key = self.format_prometheus_metrics_name("{}_{}_{}".format(check_command, service, "metadata"), entry,
+                        prometheus_key = self.format_prometheus_metrics_name("{}_{}".format(check_command, "metadata"), entry,
                                                                                      {})
                         
                         prometheus_key_with_labels = Perfdata.concat_metrics_name_and_labels(labels,

--- a/icinga2_exporter/perfdata.py
+++ b/icinga2_exporter/perfdata.py
@@ -73,7 +73,7 @@ class Perfdata:
                         for perf_data_key, perf_data_value in perf.items():
 
                             if 'value' in perf_data_value:
-                                prometheus_key = self.format_promethues_metrics_name(check_command, perf_data_key,
+                                prometheus_key = self.format_prometheus_metrics_name(check_command, perf_data_key,
                                                                                      perf_data_value)
 
                                 # Add more labels based on perfname
@@ -90,7 +90,7 @@ class Perfdata:
 
         return self.perfdatadict
 
-    def format_promethues_metrics_name(self, check_command, key, value):
+    def format_prometheus_metrics_name(self, check_command, key, value):
         """
         Format the prometheues metrics name according to naming configuration
         Typical

--- a/icinga2_exporter/proxy.py
+++ b/icinga2_exporter/proxy.py
@@ -46,7 +46,14 @@ async def get_ametrics():
     monitor_data = Perfdata(monitorconnection.MonitorConfig(), target)
 
     # Fetch performance data from Monitor
-    await asyncio.get_event_loop().create_task(monitor_data.get_perfdata())
+    loop = asyncio.get_event_loop()
+    fetch_perfdata_task = loop.create_task(monitor_data.get_perfdata())
+
+    if monitorconnection.MonitorConfig().get_enable_scrape_metadata():
+        fetch_metadata_task = loop.create_task(monitor_data.get_metadata())
+        await fetch_metadata_task
+
+    await fetch_perfdata_task
 
     target_metrics = monitor_data.prometheus_format()
 


### PR DESCRIPTION
Adds the option to scrape additional host metadata like host state.
### Modifications:
- New config option to enable feature
- Second async request to get additional data from the hosts endpoint of the icinga api
### Motivation:
This allows us to retire graphite and directly scrap via prometheus.