### PR TITLE
Add ability to export thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Benefits:
 ## Metric names
 Metrics that is scraped with the icinga2-exporter will have the following name structure:
 
-    icinga2_<check_command>_<perfname>_<unit>
+    <metric_prefix>_<check_command>_<perfname>_<unit>
 
-> The icinga2 prefix can be changed by the configuration
+> The metric_prefix can be changed by the configuration, defaults to icinga2
+> 
 > Unit is only added if it exists on performance data
 
 Example from check command `check_ping` will result in two metrics:
@@ -111,39 +112,76 @@ Example:
 #port: 9638
 
 icinga2:
-  # The url to the icinga2 server
-  url: https://127.0.0.1:5665
-  user: root
-  passwd: cf593406ffcfd2ef
-  # All prometheus metrics will be prefixed with this string
-  metric_prefix: icinga2
-  # Example of custom vars that should be added as labels and how to be translated
-  host_custom_vars:
-    # Specify which custom_vars to extract from hosts in icinga2
-    - env:
-        # Name of the label in Prometheus
-        label_name: environment
-    - site:
-        label_name: dc
+   # The url to the icinga2 server
+   url: https://127.0.0.1:5665
+   # The icinga2 username
+   user: root
+   # The icinga2 password
+   passwd: cf593406ffcfd2ef
+   # Verify the ssl certificate, default false
+   verify: false
+   # Timeout accessing icinga server, default 5 sec
+   timeout: 5
+   # All prometheus metrics will be prefixed with this string
+   metric_prefix: icinga2
+   # Enables a separate request to fetch host metadata like state and state_type. Default false
+   enable_scrape_metadata: true
+   # Enables export of warning and critical threshold values. Default false
+   enable_scrape_thresholds: false
 
-  # This section enable that for specific check commands the perfdata metrics name will not be part of the
-  # prometheus metrics name, instead moved to a label
-  # E.g for the disk command the perfdata name will be set to the label disk like:
-  # icinga2_disk_bytes{hostname="icinga2", service="disk", os="Docker", disk="/var/log/icinga2"}
-  perfnametolabel:
+   # Set the service name for host check metric, default is alive - only change this if it is a name conflict with other
+   # services
+   # host_check_service_name: alive
+
+   # Example of host customer variables that should be added as labels and how to be translated
+   host_custom_vars:
+      # Specify which custom_vars to extract from hosts in icinga2
+      - env:
+           # Name of the label in Prometheus
+           label_name: environment
+      - site:
+           label_name: dc
+
+   # This section enable that for specific check commands the perfdata metrics name will not be part of the
+   # prometheus metrics name, instead moved to a label
+   # E.g for the disk command the perfdata name will be set to the label disk like:
+   # icinga2_disk_bytes{hostname="icinga2", service="disk", os="Docker", disk="/var/log/icinga2"}
+   perfnametolabel:
       # The command name
       disk:
-        # the label name to be used
-        label: mount
+         # the label name to be used
+         label_name: mount
 
 logger:
-  # Path and name for the log file. If not set send to stdout
-  logfile: /var/tmp/icinga2-exporter.log
-  # Log level
-  level: INFO
+   # Path and name for the log file. If not set send to stdout
+   logfile: /var/tmp/icinga2-exporter.log
+   # Log level
+   level: INFO
 ```
 
 > When running with gunicorn the port is selected by gunicorn
+
+## enable_scrape_thresholds
+
+Set this to `true` to scrape warning and critical threshold values.
+
+Thresholds that are scraped with the icinga2-exporter will have the following name structure:
+
+    <metric_prefix>_<check_command>_<perfname>_<unit>_threshold_critical
+    <metric_prefix>_<check_command>_<perfname>_<unit>_threshold_warning
+
+> The metric_prefix can be changed by the configuration, defaults to icinga2
+> 
+> Unit is only added if it exists on performance data
+
+Example from check command `check_ping` will result in two metrics together with metrics for critical and warning thresholds:
+
+    icinga2_ping4_rta_seconds
+    icinga2_ping4_rta_seconds_threshold_critical
+    icinga2_ping4_rta_seconds_threshold_warning
+    icinga2_ping_pl_ratio
+    icinga2_ping4_pl_ratio_threshold_critical
+    icinga2_ping4_pl_ratio_threshold_warning
 
 ## Logging
 

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
-# Port can be overridden by using -p if running development flask
-#port: 9631
+# Port can be overridden by using -p if running development quart
+#port: 9638
 
 icinga2:
   # The url to the icinga2 server
@@ -14,7 +14,7 @@ icinga2:
   timeout: 5
   # All prometheus metrics will be prefixed with this string
   metric_prefix: icinga2
-  # Enables a separate request to fetch host metadata like state and state_type
+  # Enables a separate request to fetch host metadata like state and state_type. Default false
   enable_scrape_metadata: true
   # Enables export of warning and critical threshold values. Default false
   enable_scrape_thresholds: false

--- a/config.yml
+++ b/config.yml
@@ -16,8 +16,8 @@ icinga2:
   metric_prefix: icinga2
   # Enables a separate request to fetch host metadata like state and state_type
   enable_scrape_metadata: true
-  # Enables export of warning and critical threshold values
-  enable_scrape_thresholds: true
+  # Enables export of warning and critical threshold values. Default false
+  enable_scrape_thresholds: false
 
   # Set the service name for host check metric, default is alive - only change this if it is a name conflict with other
   # services

--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,8 @@ icinga2:
   metric_prefix: icinga2
   # Enables a separate request to fetch host metadata like state and state_type
   enable_scrape_metadata: true
+  # Enables export of warning and critical threshold values
+  enable_scrape_thresholds: true
 
   # Set the service name for host check metric, default is alive - only change this if it is a name conflict with other
   # services

--- a/icinga2_exporter/monitorconnection.py
+++ b/icinga2_exporter/monitorconnection.py
@@ -71,6 +71,7 @@ class MonitorConfig(object, metaclass=Singleton):
         self.url_query_service_perfdata = ''
         self.perfname_to_label = []
         self.host_check_service_name = 'alive'
+        self.enable_scrape_thresholds = False
 
         if config:
             self.user = config[MonitorConfig.config_entry]['user']
@@ -90,9 +91,14 @@ class MonitorConfig(object, metaclass=Singleton):
                 self.enable_scrape_metadata = bool(config[MonitorConfig.config_entry]['enable_scrape_metadata'])
             if 'host_check_service_name' in config[MonitorConfig.config_entry]:
                 self.host_check_service_name = config[MonitorConfig.config_entry]['host_check_service_name']
+            if 'enable_scrape_thresholds' in config[MonitorConfig.config_entry]:
+                self.enable_scrape_thresholds = bool(config[MonitorConfig.config_entry]['enable_scrape_thresholds'])
 
             self.url_query_service_perfdata = self.host + '/v1/objects/services'
             self.url_query_host_metadata = self.host + '/v1/objects/hosts/{hostname}'
+
+    def get_enable_scrape_thresholds(self):
+        return self.enable_scrape_thresholds
 
     def get_enable_scrape_metadata(self):
         return self.enable_scrape_metadata
@@ -190,4 +196,3 @@ class MonitorConfig(object, metaclass=Singleton):
             raise ScrapeExecption(message=f"Timeout after {self.timeout} sec", err=err, url=self.host)
         except ClientConnectorError as err:
             raise ScrapeExecption(message="Connection error", err=err, url=self.host)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-aiohttp==3.8.5
+aiohttp==3.10.10
 asyncio==3.4.3
 prometheus-client==0.14.1
 python-json-logger==2.0.2
-PyYAML==6.0
+PyYAML==6.0.2
 quart==0.17.0
 requests==2.31.0
 werkzeug==2.3.7


### PR DESCRIPTION
Added ability to export warning and critical threshold values for host and services. Threshold values are fetched from the performance data.

Feature is disabled by default.